### PR TITLE
[FEATURE] Merge nginx.locations from data bags

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -97,7 +97,7 @@ GRAPH
     packagecloud (>= 0.0.0)
     yum-epel (>= 0.0.0)
   screen (0.7.0)
-  site-proxytypo3org (1.3.0)
+  site-proxytypo3org (0.0.0)
     build-essential (= 2.2.4)
     haproxy (= 2.0.2)
     logrotate (= 1.9.2)

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ It installs
 
 ## Cookbooks:
 
-* t3-base (~> 0.2.0)
+* t3-base (~> 0.2.59)
 * zabbix-custom-checks (~> 0.2.0)
 * ssl_certificates
 * nginx (= 2.7.6)
 * nginx_conf (= 1.0.1)
 * logrotate (= 1.9.2)
-* haproxy (= 1.6.7)
+* haproxy (= 2.0.2)
 * openssl (= 4.4.0)
 * build-essential (= 2.2.4)
 
@@ -92,7 +92,7 @@ Every proxy site needs a backend specified (minimum viable example):
 
 ### Parametrized Site
 
-Optionally, additional parameters can be specified using the `options` key:
+Optionally, additional parameters can be specified using the `options` and `locations` keys:
 
 ```javascript
 {
@@ -103,12 +103,12 @@ Optionally, additional parameters can be specified using the `options` key:
     "options": {
       "add_header": {
         "Strict-Transport-Security": "\"max-age=15768000; preload;\""
-      },
-      "locations": {
-        "/api/": {
-          "proxy_pass":  "http://api.example.org/",
-          "proxy_set_header": "Host api.example.org"
-        }
+      }
+    },
+    "locations": {
+      "/api/": {
+        "proxy_pass":  "http://api.example.org/",
+        "proxy_set_header": "Host api.example.org"
       }
     }
   }
@@ -121,8 +121,8 @@ The following snippet can be used send a redirect from subdomain `redirect.examp
 
 ```javascript
 {
-  "id": "redirect.typo3.org",
-  "name": "redirect.typo3.org",
+  "id": "redirect.example.org",
+  "name": "redirect.example.org",
   "nginx": {
     // backend needs to be filled
     "backend": "http://does.not.matter.example.org:80",
@@ -164,7 +164,7 @@ The `action` key can be specified both on top level, as well as below the `nginx
 
 For non-HTTP traffic, HAproxy serves for load balancing / redirection of traffic towards the backends.
 
-This setup makes use of the [`haproxy_lb`](https://github.com/sous-chefs/haproxy/blob/v2.0.2/README.md#haproxy_lb) resource from the [`haproxy`](https://supermarket.chef.io/cookbooks/haproxy) cookbook.
+This cookbook passes all data bag information to the [`haproxy_lb`](https://github.com/sous-chefs/haproxy/blob/v2.0.2/README.md#haproxy_lb) resource (implemented in [`site-proxytypo3org::_haproxy_sites`](https://github.com/TYPO3-cookbooks/site-proxytypo3org/blob/master/recipes/_haproxy_sites.rb)).
 
 ### Simple HAProxy Config
 
@@ -194,7 +194,7 @@ If additional parameters for the HAproxy config need to be specified, these have
 ```javascript
 {
   "id": "parametrized.example.org",
-  "name": "parametrized.typo3.org",
+  "name": "parametrized.example.org",
   "haproxy": {
     "parametrized-12345": {
       "mode": "tcp",
@@ -215,6 +215,7 @@ If additional parameters for the HAproxy config need to be specified, these have
 ### Deletion
 
 There is no need to explicitly delete HAproxy configs. If the data bag item is removed, the next chef run will not include it anymore.
+
 
 # License and Maintainer
 

--- a/doc/databags.md
+++ b/doc/databags.md
@@ -47,7 +47,7 @@ Every proxy site needs a backend specified (minimum viable example):
 
 ### Parametrized Site
 
-Optionally, additional parameters can be specified using the `options` key: 
+Optionally, additional parameters can be specified using the `options` and `locations` keys: 
 
 ```javascript
 {
@@ -58,12 +58,12 @@ Optionally, additional parameters can be specified using the `options` key:
     "options": {
       "add_header": {
         "Strict-Transport-Security": "\"max-age=15768000; preload;\""
-      },
-      "locations": {
-        "/api/": {
-          "proxy_pass":  "http://api.example.org/",
-          "proxy_set_header": "Host api.example.org"
-        }
+      }
+    },
+    "locations": {
+      "/api/": {
+        "proxy_pass":  "http://api.example.org/",
+        "proxy_set_header": "Host api.example.org"
       }
     }
   }

--- a/recipes/_nginx_sites.rb
+++ b/recipes/_nginx_sites.rb
@@ -15,6 +15,8 @@ sites.each do |site|
     raise "Action '#{specified_action}' for site #{site['name']} is invalid. Valid options are #{valid_actions.implode(', ')}" unless valid_actions.include? specified_action
   end
 
+  locations = Chef::Mixin::DeepMerge.deep_merge!(node['nginx_conf']['locations'], site['nginx']['locations'])
+
   # HTTPS vhost
   nginx_conf_file site['name'] do
     listen(["443 ssl http2", "[::]:443 ssl http2"])
@@ -23,6 +25,7 @@ sites.each do |site|
     ssl nil
     template "nginx_site.erb"
     cookbook cookbook_name
+    locations locations
     options site['nginx']['options'] || {}
     action specified_action || :create
   end

--- a/test/integration/data_bags/proxy/test_location.json
+++ b/test/integration/data_bags/proxy/test_location.json
@@ -1,0 +1,15 @@
+{
+  "id": "test_location.example.org",
+  "name": "test_location.example.org",
+  "nginx": {
+    "backend": "http://192.0.2.1:80",
+    "locations": {
+      "/": {
+        "proxy_http_version": "1.1"
+      },
+      "/test": {
+        "proxy_http_version": "1.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Previously, the `locations` parameter of the `nginx_conf_file`
resource was unused. This limited the flexibility in the data
bag items, as we were not able to specify options for `/`.

Now, the defaults from `node['nginx_conf']['locations']` (defined
in `attributes/nginx.rb` get deep-merged with those specified in
data bag below nginx.locations:

```json
{
  "id": "websockets.example.org",
  "name": "websockets.example.org",
  "nginx": {
    "backend": "http://192.0.2.1:80",
    "locations": {
      "/": {
        "proxy_http_version": "1.1",
        "proxy_set_header": {
          "Upgrade": "$http_upgrade",
          "Connection": "\"upgrade\""
        }
      }
    }
  }
}
```