### PR TITLE
[TASK] #83100 configure X-Forwarded-Proto header

### DIFF
--- a/attributes/nginx.rb
+++ b/attributes/nginx.rb
@@ -26,6 +26,7 @@ default['nginx_conf']['locations'] = {
       'Host' => '$http_host',
       'X-Forwarded-For' => '$proxy_add_x_forwarded_for',
       'X-Forwarded-Port' => '$server_port',
+      'X-Forwarded-Proto' => '$scheme',
       'X-Real-IP' => '$remote_addr',
       'HTTPS' => 'on', # we only use HTTPS on this proxy (except for redirect vhosts)
       'Proxy' => '""', # mitigate httpoxy vulnerability


### PR DESCRIPTION
Add X-Forwarded-Proto header which will allow backend applications to distinguish between HTTP/HTTPS requests.

See [Forge Ticket #83100](https://forge.typo3.org/issues/83100) for a actual application with MediaWiki.