### PR TITLE
[TASKS] Disable monitoring tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,13 +25,13 @@ suites:
     driver_config:
       network:
       - ["private_network", {ip: "192.168.88.18"}]
-  - name: monitoring
-    run_list:
-      - recipe[site-proxytypo3org::default]
-    attributes:
-      t3-base:
-        flags:
-          # test with zabbix
-          production: true
-      site-proxytypo3org:
-        ssl_certificate: wildcard.vagrant
+#  - name: monitoring
+#    run_list:
+#      - recipe[site-proxytypo3org::default]
+#    attributes:
+#      t3-base:
+#        flags:
+#          # test with zabbix
+#          production: true
+#      site-proxytypo3org:
+#        ssl_certificate: wildcard.vagrant


### PR DESCRIPTION
This often results in a 401 Unauthorized at the end of the run.

Running handlers:

[2017-11-27T19:57:54+01:00] ERROR: Running exception handlers

  - Zabbix::Report

[2017-11-27T19:57:54+01:00] ERROR: Report handler LastRunUpdateHandler raised #<Net::HTTPServerException: 401 "Unauthorized">

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/2.3.0/net/http/response.rb:120:in `error!'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/http.rb:150:in `request'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/http.rb:123:in `put'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/node.rb:597:in `save'

[2017-11-27T19:57:54+01:00] ERROR: /var/chef/handlers/lastrun_update.rb:36:in `report'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/handler.rb:259:in `run_report_unsafe'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/handler.rb:247:in `run_report_safely'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/handler.rb:151:in `block in run_exception_handlers'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/handler.rb:149:in `each'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/handler.rb:149:in `run_exception_handlers'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/handler.rb:160:in `block in <class:Handler>'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/client.rb:455:in `block in run_failed'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/client.rb:454:in `each'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/client.rb:454:in `run_failed'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/client.rb:316:in `rescue in run'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/client.rb:323:in `run'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application.rb:295:in `block in fork_chef_client'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application.rb:283:in `fork'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application.rb:283:in `fork_chef_client'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application.rb:248:in `block in run_chef_client'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/local_mode.rb:44:in `with_server_connectivity'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application.rb:236:in `run_chef_client'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application/client.rb:464:in `sleep_then_run_chef_client'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application/client.rb:451:in `block in interval_run_chef_client'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application/client.rb:450:in `loop'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application/client.rb:450:in `interval_run_chef_client'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application/client.rb:434:in `run_application'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/lib/chef/application.rb:59:in `run'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.3.0/gems/chef-12.21.3/bin/chef-client:26:in `<top (required)>'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/bin/chef-client:22:in `load'

[2017-11-27T19:57:54+01:00] ERROR: /opt/chef/embedded/bin/chef-client:22:in `<main>'

  - LastRunUpdateHandler

  - Etckeeper::CommitHandler

Running handlers complete

[2017-11-27T19:57:55+01:00] ERROR: Exception handlers complete

Chef Client failed. 227 resources updated in 04 minutes 42 seconds

[2017-11-27T19:57:55+01:00] FATAL: Stacktrace dumped to /opt/kitchen/cache/chef-stacktrace.out

[2017-11-27T19:57:55+01:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report

[2017-11-27T19:57:55+01:00] ERROR: 401 "Unauthorized"

[2017-11-27T19:57:55+01:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)